### PR TITLE
Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [ "8.1", "8.2", "8.3", "8.4" ]
+                php: [ "8.2", "8.3", "8.4" ]
                 laravel: [ "8.0", "9.0", "10.0", "11.0", "12.0" ]
                 exclude:
                     - laravel: 8.0
@@ -23,12 +23,6 @@ jobs:
                       
                     - laravel: 9.0
                       php: 8.4
-                      
-                    - laravel: 11.0
-                      php: 8.1
-                      
-                    - laravel: 12.0
-                      php: 8.1
                       
 
         name: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or manually update `require` block of `composer.json` and run composer update.
 ```json
 {
     "require": {
-        "dragon-code/size-sorter": "^1.0"
+        "dragon-code/size-sorter": "^2.0"
     }
 }
 ```
@@ -35,7 +35,7 @@ Or manually update `require` block of `composer.json` and run composer update.
 
 | Compatibility | Versions |
 |:--------------|:---------|
-| PHP           | 8.1+     |
+| PHP           | 8.2+     |
 | Laravel       | 8.0+     |
 | Symfony       | 5.3+     |
 

--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "archtechx/enums": "^0.3.1 || ^1.0",
         "dragon-code/support": "^6.9",
-        "illuminate/collections": "^8.75 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
+        "illuminate/collections": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
         "dragon-code/codestyler": "^6.0",
         "fakerphp/faker": "^1.21",
-        "illuminate/database": "^8.75 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/database": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
         "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0 || ^12.0",
         "symfony/var-dumper": "^5.3 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
