### PR TITLE
Drop old PHPUnit versions support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,9 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: composer require --dev laravel/framework:^${{ matrix.laravel }}
+                run: composer require \
+                    illuminate/collections:^${{ matrix.laravel }} \
+                    illuminate/database:^${{ matrix.laravel }}
 
             -   name: Execute tests
                 run: composer test

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "dragon-code/codestyler": "^6.0",
         "fakerphp/faker": "^1.21",
         "illuminate/database": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
-        "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0 || ^12.0",
+        "phpunit/phpunit": "^12.0",
         "symfony/var-dumper": "^5.3 || ^6.0 || ^7.0"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "dragon-code/codestyler": "^6.0",
         "fakerphp/faker": "^1.21",
         "illuminate/database": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
-        "phpunit/phpunit": "^12.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
         "symfony/var-dumper": "^5.3 || ^6.0 || ^7.0"
     },
     "minimum-stability": "stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="false"
-        convertWarningsToExceptions="false"
-        processIsolation="false"
-        stopOnError="true"
-        stopOnFailure="true"
-        verbose="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         stopOnError="true"
+         stopOnFailure="true"
+         cacheResult="false"
 >
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
