### PR TITLE
Dropping support for compatibility with older versions of Laravel (8-10)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,21 +10,8 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ "8.2", "8.3", "8.4" ]
-                laravel: [ "8.0", "9.0", "10.0", "11.0", "12.0" ]
-                exclude:
-                    - laravel: 8.0
-                      php: 8.3
-                      
-                    - laravel: 8.0
-                      php: 8.4
-                      
-                    - laravel: 98.0
-                      php: 8.3
-                      
-                    - laravel: 9.0
-                      php: 8.4
-                      
-
+                laravel: [ "11.0", "12.0" ]
+        
         name: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}
 
         steps:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Or manually update `require` block of `composer.json` and run composer update.
 }
 ```
 
+> [!TIP]
+> 
+> When using the Laravel framework, make sure that its version is 11.0 or greater.
+
 ## Usage
 
 When calling a sort with common values, each element will be assigned to one of five groups:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,11 +2,19 @@
 
 ## To 2.x from 1.0
 
+### PHP 8.2.0 Required
+
+`Size Sorter` now requires PHP 8.2.0 or greater.
+
 ### Updating Dependencies
 
 You should update the following dependencies in your application's `composer.json` file:
 
 - `dragon-code/size-sorter` to `^2.0`
+
+### Frameworks Compatibility
+
+When using the Laravel framework, make sure that its version is 11.0 or greater.
 
 ### Changing Namespace
 

--- a/composer.json
+++ b/composer.json
@@ -36,14 +36,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/collections": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
+        "illuminate/collections": "^11.0 || ^12.0"
     },
     "require-dev": {
         "dragon-code/codestyler": "^6.0",
         "fakerphp/faker": "^1.21",
-        "illuminate/database": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
-        "phpunit/phpunit": "^11.0 || ^12.0",
-        "symfony/var-dumper": "^5.3 || ^6.0 || ^7.0"
+        "illuminate/database": "^11.0 || ^12.0",
+        "phpunit/phpunit": "^12.0",
+        "symfony/var-dumper": "^7.0"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "dragon-code/codestyler": "^6.0",
         "fakerphp/faker": "^1.21",
         "illuminate/database": "^11.0 || ^12.0",
-        "phpunit/phpunit": "^12.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
         "symfony/var-dumper": "^7.0"
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
